### PR TITLE
Electron / Browser platform support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ignore any IDE or OS-generated data
-node_modules
+node_modules/
+src/windows/FontsProxy/obj/
 
 *.csproj.user
 *.suo

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Firefox OS does not provide an API to access the fonts on the device. The Fonts 
 
 The cordova-fonts plugin uses the cordova-plugin-test-framework to run unit tests. Complete the following to run through the plugin unit tests:
 
-1. Use your existing cordova app, or create a new one.
+1. Use your existing cordova app, or create a new one. You can also use the test project that has already been set up for this over at https://github.com/eb1/test-fonts (just use the instructions listed there instead of the ones below).
 2. Add the cordova-fonts plugin and test / test framework plugins:
 
         cordova plugin add https://github.com/adapt-it/cordova-fonts.git

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 # cordova-plugin-fonts
 
-| Download Activity | Travis CI |
-|:-:|:-:|
-| [![npm](https://img.shields.io/npm/dm/cordova-plugin-fonts.svg)](https://www.npmjs.com/package/cordova-plugin-fonts) | [![Build Status](https://travis-ci.org/adapt-it/cordova-fonts.svg?branch=master)](https://travis-ci.org/adapt-it/cordova-fonts) |
+| Download Activity | Travis CI | Snyk |
+|:-:|:-:|:-:|
+| [![npm](https://img.shields.io/npm/dm/cordova-plugin-fonts.svg)](https://www.npmjs.com/package/cordova-plugin-fonts) | [![Build Status](https://travis-ci.org/adapt-it/cordova-fonts.svg?branch=master)](https://travis-ci.org/adapt-it/cordova-fonts) | [![Known Vulnerabilities](https://snyk.io/test/github/adapt-it/cordova-fonts/badge.svg)](https://snyk.io/test/github/adapt-it/cordova-fonts) |
 
 A Cordova plugin that enumerates the fonts installed on the local device, and also provides the name of the default font.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The cordova-fonts plugin uses the cordova-plugin-test-framework to run unit test
 
         cordova plugin add https://github.com/adapt-it/cordova-fonts.git
         cordova plugin add https://github.com/adapt-it/cordova-fonts.git#:/tests
-        cordova plugin add http://git-wip-us.apache.org/repos/asf/cordova-plugin-test-framework.git
+        cordova plugin add https://github.com/apache/cordova-plugin-test-framework.git
 
 3. Change the start page in your cordova app's `config.xml` with `<content src="cdvtests/index.html" />` or navigate to `cdvtests/index.html` from within your app.
 4. Build and run the application in an emulator or on the device.

--- a/doc/index.md
+++ b/doc/index.md
@@ -42,7 +42,7 @@ These commands will install the plugin from npm. You can find this plugin up on 
 ## Supported Platforms
 
 - Android
-- Amazon Fire OS (untested / just using Android code)
+- Amazon Fire OS (deprecated in newer versions of Cordova / just uses Android code)
 - Firefox OS
 - iOS
 

--- a/src/windows/FontsProxy/Cordova/JSON/JsonHelper.cs
+++ b/src/windows/FontsProxy/Cordova/JSON/JsonHelper.cs
@@ -1,0 +1,87 @@
+/*  
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace FontsProxy.Cordova.JSON
+{
+    /// <summary>
+    /// Provides JSON serialization/deserialization functionality.
+    /// </summary>
+    static class JsonHelper
+    {
+        /// <summary>
+        /// Serializes object to JSON string representation
+        /// </summary>
+        /// <param name="obj">object to serialize</param>
+        /// <returns>JSON representation of the object. Returns 'null' string for null passed as argument</returns>
+        public static string Serialize(object obj)
+        {
+            if (obj == null)
+            {
+                return "null";
+            }
+
+            DataContractJsonSerializer ser = new DataContractJsonSerializer(obj.GetType());
+
+            MemoryStream ms = new MemoryStream();
+            ser.WriteObject(ms, obj);
+
+            ms.Position = 0;
+
+            string json = String.Empty;
+
+            using (StreamReader sr = new StreamReader(ms))
+            {
+                json = sr.ReadToEnd();
+            }
+
+            ms.Dispose();
+
+            return json;
+
+        }
+
+        /// <summary>
+        /// Parses json string to object instance
+        /// </summary>
+        /// <typeparam name="T">type of the object</typeparam>
+        /// <param name="json">json string representation of the object</param>
+        /// <returns>Deserialized object instance</returns>
+        public static T Deserialize<T>(string json)
+        {
+            DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
+            object result = null;
+            try
+            {
+                using (MemoryStream mem = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                {
+                    result = deserializer.ReadObject(mem);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                Debug.WriteLine("Failed to deserialize " + typeof(T) + " with JSON value :: " + json);
+            }
+
+            return (T)result;
+
+        }
+    }
+}

--- a/src/windows/FontsProxy/FontsProxy.cs
+++ b/src/windows/FontsProxy/FontsProxy.cs
@@ -1,0 +1,24 @@
+﻿/*  
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Runtime.Serialization;
+using FontsProxy.Cordova.JSON;
+
+namespace FontsProxy
+{
+    public sealed class FontsProxy
+    {
+    }
+}

--- a/src/windows/FontsProxy/FontsProxy.csproj
+++ b/src/windows/FontsProxy/FontsProxy.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D6705BE5-A02C-40A0-BB00-2E7E19D9D8CB}</ProjectGuid>
+    <OutputType>winmdobj</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FontsProxy</RootNamespace>
+    <AssemblyName>FontsProxy</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile32</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <TargetPlatform Include="Windows, Version=8.1" />
+    <TargetPlatform Include="WindowsPhoneApp, Version=8.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FontsProxy.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/windows/FontsProxy/FontsProxy.sln
+++ b/src/windows/FontsProxy/FontsProxy.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FontsProxy", "FontsProxy.csproj", "{D6705BE5-A02C-40A0-BB00-2E7E19D9D8CB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D6705BE5-A02C-40A0-BB00-2E7E19D9D8CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6705BE5-A02C-40A0-BB00-2E7E19D9D8CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6705BE5-A02C-40A0-BB00-2E7E19D9D8CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6705BE5-A02C-40A0-BB00-2E7E19D9D8CB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/windows/FontsProxy/JsonHelper.cs
+++ b/src/windows/FontsProxy/JsonHelper.cs
@@ -1,0 +1,87 @@
+/*  
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace FontsProxy.Cordova.JSON
+{
+    /// <summary>
+    /// Provides JSON serialization/deserialization functionality.
+    /// </summary>
+    static class JsonHelper
+    {
+        /// <summary>
+        /// Serializes object to JSON string representation
+        /// </summary>
+        /// <param name="obj">object to serialize</param>
+        /// <returns>JSON representation of the object. Returns 'null' string for null passed as argument</returns>
+        public static string Serialize(object obj)
+        {
+            if (obj == null)
+            {
+                return "null";
+            }
+
+            DataContractJsonSerializer ser = new DataContractJsonSerializer(obj.GetType());
+
+            MemoryStream ms = new MemoryStream();
+            ser.WriteObject(ms, obj);
+
+            ms.Position = 0;
+
+            string json = String.Empty;
+
+            using (StreamReader sr = new StreamReader(ms))
+            {
+                json = sr.ReadToEnd();
+            }
+
+            ms.Dispose();
+
+            return json;
+
+        }
+
+        /// <summary>
+        /// Parses json string to object instance
+        /// </summary>
+        /// <typeparam name="T">type of the object</typeparam>
+        /// <param name="json">json string representation of the object</param>
+        /// <returns>Deserialized object instance</returns>
+        public static T Deserialize<T>(string json)
+        {
+            DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
+            object result = null;
+            try
+            {
+                using (MemoryStream mem = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                {
+                    result = deserializer.ReadObject(mem);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                Debug.WriteLine("Failed to deserialize " + typeof(T) + " with JSON value :: " + json);
+            }
+
+            return (T)result;
+
+        }
+    }
+}

--- a/src/windows/FontsProxy/Properties/AssemblyInfo.cs
+++ b/src/windows/FontsProxy/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FontsProxy")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FontsProxy")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/wp/Fonts.cs
+++ b/src/wp/Fonts.cs
@@ -26,4 +26,36 @@ namespace WPCordovaClassLib.Cordova.Commands
             }
         }
     }
+
+    /// <summary>
+    /// Wraps data into JSON format
+    /// Method taken from Apache / cordova-plugin-globalization
+    /// </summary>
+    /// <param name="data">data</param>
+    /// <returns>data formatted as JSON object</returns>
+    static string WrapIntoJSON<T>(T data, string keyName = "value", string stringifiedData = null)
+    {
+        string param = "{0}";
+        stringifiedData = stringifiedData ?? data.ToString();
+
+        if (data.GetType() == typeof(string))
+        {
+            param = "\"" + param + "\"";
+        }
+
+        if (data.GetType() == typeof(bool))
+        {
+            stringifiedData = stringifiedData.ToLower();
+        }
+
+        if (data.GetType() == typeof(string[]))
+        {
+            stringifiedData = JsonHelper.Serialize(data);
+        }
+
+        var formattedData = string.Format("\"" + keyName + "\":" + param, stringifiedData);
+        formattedData = "{" + formattedData + "}";
+
+        return formattedData;
+    }    
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cordova-plugin-fonts-tests",
+  "version": "0.7.0",
+  "description": "",
+  "cordova": {
+    "id": "cordova-plugin-fonts-tests",
+    "platforms": [
+        "firefoxos",
+        "android",
+        "ios",
+        "windows"
+    ]
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios",
+    "cordova-firefox",
+    "cordova-windows"
+  ],
+  "license": "Apache-2.0",
+  "author": "Erik Brommers"
+}


### PR DESCRIPTION
Fixes #6 , #7 

Browser and Electron platforms use just Javascript to determine the fonts on the local device, and will test the browser for [local font access API](https://developer.mozilla.org/en-US/docs/Web/API/Local_Font_Access_API) support. If the browser supports the API, it will return a string array of the font data's [font family](https://developer.mozilla.org/en-US/docs/Web/API/FontData/family) for each supported font. If the underlying browser _does not_ support the API, the plugin iterates through known browser-safe fonts and tries to detect their presence on the device. Note that Electron uses Chromium as its browser, which does appear to support the API.

Also deprecated support for the Windows (wp8 / uwp), Amazon Fire OS, and Firefox OS platforms. These platforms are no longer supported by Apache Cordova.